### PR TITLE
fix: make clean Uint8Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,7 @@ module.exports = multiformats => {
   const defaultTags = {
     [CID_CBOR_TAG]: (val) => {
       // remove that 0
-      val = val.slice(1)
-      val = bytes.coerce(val)
+      val = Uint8Array.from(val.slice(1))
       const [version] = varint.decode(val)
       if (version > 1) {
         // CIDv0

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -75,6 +75,14 @@ describe('util', () => {
     same(deserialized, slashObject)
   })
 
+  test('CIDs have clean for deep comparison', () => {
+    const deserializedObj = decode(serializedObj)
+    // backing buffer must be pristine as some comparison libraries go that deep
+    const actual = new Uint8Array(deserializedObj.link.buffer.buffer).join(',')
+    const expected = obj.link.buffer.join(',')
+    same(actual, expected)
+  })
+
   test('error catching', () => {
     const circlarObj = {}
     circlarObj.a = circlarObj


### PR DESCRIPTION
See https://github.com/browserify/commonjs-assert/blob/v1.5.0/assert.js#L293-L294 for an example of why this can fail, the slice doesn't remove from the backing buffer. Yes that comparison is wrong but it's the version of `assert` that we're stuck with in Webpack without explicitly pulling in a newer version.

I'm also considering if maybe we shouldn't be doing a `Uint8Array.from(o)` in the `coerce()` function just to be sure.