### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,18 +39,15 @@
   "dependencies": {
     "borc": "^2.1.2",
     "buffer": "^5.5.0",
-    "cids": "~0.8.0",
+    "cids": "^0.8.1",
     "is-circular": "^1.0.2",
     "multicodec": "^1.0.0",
-    "multihashing-async": "~0.8.0"
+    "multihashing-async": "^0.8.1"
   },
   "devDependencies": {
-    "aegir": "^21.0.1",
-    "chai": "^4.2.0",
+    "aegir": "^22.0.0",
     "detect-node": "^2.0.4",
-    "dirty-chai": "^2.0.1",
-    "garbage": "0.0.0",
-    "multihashes": "~0.4.14"
+    "garbage": "0.0.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/test/interop.spec.js
+++ b/test/interop.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const dagCBOR = require('../src')
 const loadFixture = require('aegir/fixtures')
 const isNode = require('detect-node')

--- a/test/mod.spec.js
+++ b/test/mod.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multicodec = require('multicodec')
 
 const mod = require('../src')

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -2,10 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 5] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 const CID = require('cids')
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -2,13 +2,10 @@
 'use strict'
 
 const { Buffer } = require('buffer')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const garbage = require('garbage')
 const dagCBOR = require('../src')
-const multihash = require('multihashes')
+const multihash = require('multihashing-async').multihash
 const CID = require('cids')
 
 describe('util', () => {


### PR DESCRIPTION
Uses `^` instead of `~` for semver otherwise you can end up with
duplicate modules in your bundle if one dep uses one and another uses
the other.

Also uses the chai expect command exported from aegir because it's
already preconfigured with dirty chai so fewer modules to install and
less boilerplate, hooray!