### PR TITLE
chore: pull in Uint8Array|Buffer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "garbage": "0.0.0",
     "hundreds": "0.0.2",
     "mocha": "^7.2.0",
-    "multiformats": "0.0.4",
+    "multiformats": "0.0.11",
     "polendina": "^1.0.0",
     "standard": "^14.3.4"
   },

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -112,10 +112,30 @@ describe('util', () => {
       same(decoded, original)
     }
   })
+
   test('CIDv1', () => {
     const cid = new CID('zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS')
     const encoded = encode({ link: cid })
     const decoded = decode(encoded)
     same(decoded, { link: cid })
+  })
+
+  it('encode and decode consistency  with Uint8Array and Buffer fields', () => {
+    const buffer = Buffer.from('some data')
+    const bytes = Uint8Array.from(buffer)
+
+    const s1 = encode({ data: buffer })
+    const s2 = encode({ data: bytes })
+
+    same(s1, s2)
+
+    const verify = (s) => {
+      same(typeof s, 'object')
+      same(Object.keys(s), ['data'])
+      assert(s.data instanceof Uint8Array)
+      same(s.data.buffer, bytes.buffer)
+    }
+    verify(decode(s1))
+    verify(decode(s2))
   })
 })


### PR DESCRIPTION
Not strictly necessary but this test was added to ipld-dag-cbor and it's
nice for completeness and holds us strictly to the promise of Uint8Arrays
being the primary byte holder

Ref: https://github.com/ipld/js-ipld-dag-cbor/pull/129