### PR TITLE
fix: reject CBOR data with extraneous back-to-back encoded data

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,13 @@ module.exports = multiformats => {
       throw new Error('Data is too large to deserialize with current decoder')
     }
 
-    const deserialized = decoder.decodeFirst(data)
-    return deserialized
+    // borc will decode back-to-back objects into an implicit top-level array, we
+    // strictly want to only see a single explicit top-level object
+    const all = decoder.decodeAll(data)
+    if (all.length !== 1) {
+      throw new Error('Extraneous CBOR data found beyond initial top-level object')
+    }
+    return all[0]
   }
 
   const code = 0x71

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -112,10 +112,19 @@ describe('util', () => {
       same(decoded, original)
     }
   })
+
   test('CIDv1', () => {
     const cid = new CID('zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS')
     const encoded = encode({ link: cid })
     const decoded = decode(encoded)
     same(decoded, { link: cid })
+  })
+
+  test('reject extraneous, but valid CBOR data after initial top-level object', () => {
+    assert.throws(() => {
+      // two top-level CBOR objects, the original and a single uint=0, valid if using
+      // CBOR in streaming mode, not valid here
+      decode(Buffer.concat([Buffer.from(serializedObj), Buffer.alloc(1)]))
+    }, /^Error: Extraneous CBOR data found beyond initial top-level object/)
   })
 })


### PR DESCRIPTION
Same as https://github.com/ipld/js-ipld-dag-cbor/pull/130

The streaming form of CBOR (3.1) may use back-to-back top-level objects without
an explicit container and borc will decode this without failure.
`decodeFirst()` will only return the first of these but additional data may
exist but be hidden.

Ref: https://github.com/ipld/js-ipld-dag-cbor/pull/130
Ref: https://github.com/dignifiedquire/borc/issues/47#issuecomment-642432759
Ref: https://github.com/ipld/specs/pull/268