### PR TITLE
feat!: switch CBOR library to cborg

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,11 +33,21 @@ function undefinedEncoder () {
   throw new Error('`undefined` is not supported by the IPLD Data Model and cannot be encoded')
 }
 
+function numberEncoder (num) {
+  if (Number.isNaN(num)) {
+    throw new Error('`NaN` is not supported by the IPLD Data Model and cannot be encoded')
+  }
+  if (num === Infinity || num === -Infinity) {
+    throw new Error('`Infinity` and `-Infinity` is not supported by the IPLD Data Model and cannot be encoded')
+  }
+}
+
 const encodeOptions = {
   float64: true,
   typeEncoders: {
     Object: cidEncoder,
-    undefined: undefinedEncoder
+    undefined: undefinedEncoder,
+    number: numberEncoder
   }
 }
 
@@ -55,6 +65,8 @@ function cidDecoder (bytes) {
 const decodeOptions = {
   allowIndefinite: false,
   allowUndefined: false,
+  allowNaN: false,
+  allowInfinity: false,
   allowBigInt: true, // this will lead to BigInt for ints outside of
   // safe-integer range, which may surprise users
   strict: true,

--- a/index.js
+++ b/index.js
@@ -1,141 +1,70 @@
 // @ts-check
 
-import cbor from 'borc'
-import isCircular from '@ipld/is-circular'
+import * as cborg from 'cborg'
 // @ts-ignore
-import { bytes, CID } from 'multiformats'
-
-const { asCID } = CID
-const decodeCID = CID.decode
+import { CID } from 'multiformats'
 
 // https://github.com/ipfs/go-ipfs/issues/3570#issuecomment-273931692
 const CID_CBOR_TAG = 42
-
 const code = 0x71
 const name = 'dag-cbor'
 
-function tagCID (cid) {
-  const tag = bytes.fromHex('00')
-  const buffer = new Uint8Array(tag.byteLength + cid.bytes.byteLength)
-  buffer.set(tag)
-  buffer.set(cid.bytes, tag.byteLength)
-  const tagged = new cbor.Tagged(CID_CBOR_TAG, buffer, null)
-  return tagged
+// this will receive all Objects, we need to filter out anything that's not
+// a CID and return `null` for that so it's encoded as normal
+function cidEncoder (obj) {
+  if (obj.asCID !== obj) {
+    return null // any other kind of object
+  }
+  const cid = CID.asCID(obj)
+  /* c8 ignore next 4 */
+  // very unlikely case, and it'll probably throw a recursion error in cborg
+  if (!cid) {
+    return null
+  }
+  const bytes = new Uint8Array(cid.bytes.byteLength + 1)
+  bytes.set(cid.bytes, 1) // prefix is 0x00, for historical reasons
+  return [
+    new cborg.Token(cborg.Type.tag, CID_CBOR_TAG),
+    new cborg.Token(cborg.Type.bytes, bytes)
+  ]
 }
 
-function replaceCIDbyTAG (dagNode, config) {
-  if (dagNode && typeof dagNode === 'object' && isCircular(dagNode, { asCID: true })) {
-    throw new Error('The object passed has circular references')
-  }
-
-  function transform (obj) {
-    if (bytes.isBinary(obj)) return bytes.coerce(obj)
-    if (!obj || typeof obj === 'string') {
-      return obj
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.map(transform)
-    }
-
-    const cid = asCID(obj, config)
-    if (cid) {
-      return tagCID(cid)
-    }
-
-    const keys = Object.keys(obj)
-
-    if (keys.length > 0) {
-      // Recursive transform
-      const out = {}
-      keys.forEach((key) => {
-        if (typeof obj[key] === 'object') {
-          out[key] = transform(obj[key])
-        } else {
-          out[key] = obj[key]
-        }
-      })
-      return out
-    } else {
-      return obj
-    }
-  }
-
-  return transform(dagNode)
+function undefinedEncoder () {
+  throw new Error('`undefined` is not supported by the IPLD Data Model and cannot be encoded')
 }
 
-const defaultTags = {
-  [CID_CBOR_TAG]: (val) => {
-    return decodeCID(val.subarray(1), cidConfig)
+const encodeOptions = {
+  float64: true,
+  typeEncoders: {
+    Object: cidEncoder,
+    undefined: undefinedEncoder
   }
 }
 
-const defaultSize = 64 * 1024 // current decoder heap size, 64 Kb
-const defaultMaxSize = 64 * 1024 * 1024 // max heap size when auto-growing, 64 Mb
-
-let currentSize = defaultSize
-let maxSize = defaultMaxSize
-let decoder = null
-let cidConfig = null
-
-/**
- * Configure the underlying CBOR decoder.
- *
- * @param {Object} [options] - The options the decoder takes. The decoder will reset to the defaul values if no options are given.
- * @param {number} [options.size=65536] - The current heap size used in CBOR parsing, this may grow automatically as larger blocks are encountered up to `maxSize`
- * @param {number} [options.maxSize=67108864] - The maximum size the CBOR parsing heap is allowed to grow to before `dagCBOR.util.deserialize()` returns an error
- * @param {Object} [options.tags] - An object whose keys are CBOR tag numbers and values are transform functions that accept a `value` and return a decoded representation of that `value`
- */
-const configureDecoder = (options) => {
-  const tags = defaultTags
-
-  if (options) {
-    if (typeof options.size === 'number') {
-      currentSize = options.size
-    }
-    if (typeof options.maxSize === 'number') {
-      maxSize = options.maxSize
-    }
-  } else {
-    // no options, reset to defaults
-    currentSize = defaultSize
-    maxSize = defaultMaxSize
-  }
-
-  const decoderOptions = {
-    tags,
-    size: currentSize
-  }
-
-  decoder = new cbor.Decoder(decoderOptions)
-  // borc edits opts.size in-place so we can capture _actual_ size
-  currentSize = decoderOptions.size
-}
-configureDecoder()
-
-const encode = (node, config) => {
-  const nodeTagged = replaceCIDbyTAG(node, config)
-  const serialized = cbor.encode(nodeTagged)
-  return bytes.coerce(serialized)
+function encode (node) {
+  return cborg.encode(node, encodeOptions)
 }
 
-const decode = (data, config) => {
-  cidConfig = config
-  if (data.length > currentSize && data.length <= maxSize) {
-    configureDecoder({ size: data.length })
+function cidDecoder (bytes) {
+  if (bytes[0] !== 0) {
+    throw new Error('Invalid CID for CBOR tag 42; expected leading 0x00')
   }
-
-  if (data.length > currentSize) {
-    throw new Error('Data is too large to deserialize with current decoder')
-  }
-
-  // borc will decode back-to-back objects into an implicit top-level array, we
-  // strictly want to only see a single explicit top-level object
-  const all = decoder.decodeAll(data)
-  if (all.length !== 1) {
-    throw new Error('Extraneous CBOR data found beyond initial top-level object')
-  }
-  return all[0]
+  return CID.decode(bytes.subarray(1)) // ignore leading 0x00
 }
 
-export { name, code, encode, decode, configureDecoder }
+const decodeOptions = {
+  allowIndefinite: false,
+  allowUndefined: false,
+  allowBigInt: true, // this will lead to BigInt for ints outside of
+  // safe-integer range, which may surprise users
+  strict: true,
+  useMaps: false,
+  tags: []
+}
+decodeOptions.tags[CID_CBOR_TAG] = cidDecoder
+
+function decode (data) {
+  return cborg.decode(data, decodeOptions)
+}
+
+export { name, code, encode, decode }

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "homepage": "https://github.com/ipld/js-dag-cbor",
   "dependencies": {
-    "cborg": "^1.0.2",
-    "multiformats": "^4.0.0"
+    "cborg": "^1.0.3",
+    "multiformats": "^4.4.3"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "hundreds": "0.0.8",
-    "ipld-garbage": "^1.0.3",
+    "hundreds": "^0.0.9",
+    "ipld-garbage": "^2.0.0",
     "mocha": "^8.2.1",
     "polendina": "^1.1.0",
     "standard": "^16.0.3"

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
   },
   "homepage": "https://github.com/ipld/js-dag-cbor",
   "dependencies": {
-    "@ipld/is-circular": "^2.0.0",
-    "borc": "^2.1.2",
+    "cborg": "^1.0.1",
     "multiformats": "^4.0.0"
   },
   "devDependencies": {
-    "garbage": "0.0.0",
+    "chai": "^4.2.0",
     "hundreds": "0.0.8",
-    "mocha": "^8.1.3",
+    "ipld-garbage": "^1.0.3",
+    "mocha": "^8.2.1",
     "polendina": "^1.1.0",
-    "standard": "^14.3.4"
+    "standard": "^16.0.3"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/ipld/js-dag-cbor",
   "dependencies": {
-    "cborg": "^1.0.1",
+    "cborg": "^1.0.2",
     "multiformats": "^4.0.0"
   },
   "devDependencies": {

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -118,7 +118,8 @@ describe('dag-cbor', () => {
     }
   })
 
-  test('fuzz serialize and deserialize with garbage', () => {
+  test('fuzz serialize and deserialize with garbage', function () {
+    this.timeout(5000)
     for (let ii = 0; ii < 1000; ii++) {
       const original = garbage(100)
       const encoded = encode(original)


### PR DESCRIPTION
BREAKING CHANGE!

See [cborg](https://github.com/rvagg/cborg) for additional details.

* Will be much more strict with data types on encode and decode, only
  IPLD Data Model values will be accepted, all others will be rejected
  (including `undefined`). No other tags than 42 will be involved in encode
  or decode.
* Will strictly reject decode of data where integers are encoded using more
  bytes than are required, as per deterministic DAG-CBOR rules.
* Strictly only allow tag 42 and no others. Also no exotic types like Simple Values.
* Indefinite length items will not be accepted for decode.
* BigInt will be used for integers decoded outside of the safe integer range.
  They are also accepted for encodes, within the 64-bit range. The exotic
  bignumber type from borc is no longer supported.
* **Floats are now always encoded as 64-bit**, to match the updated DAG-CBOR spec
  and the Go implementation.
* Uint8Arrays are native through the stack now, `Buffer` isn't required for
  browser bundling.
* Dependency tree is greatly simplified, should result in smaller bundle (although I haven't looked at that)
* Code here is greatly simplified, we're able to remove the object decode preparation and hook into the object tokenisation process in cborg and piggy-back that.

I will follow up with a comment about performance characteristics.

We may want to hold off on merging this PR until https://github.com/ipld/specs/issues/342 is resolved because it would be good to get strictness about rejecting the IEEE754 specials into here if that's the way we're going to go because that will be a breaking change as well. I have flags in cborg already to handle this on decode and encode can be handled here.