### PR TITLE
feat!: export object instead of default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ import { Decoder, Encoder } from 'multiformats/codecs/codec'
 
 // https://github.com/ipfs/go-ipfs/issues/3570#issuecomment-273931692
 const CID_CBOR_TAG = 42
+/** @type {number} */
 const code = 0x71
+/** @type {string} */
 const name = 'dag-cbor'
 
 // this will receive all Objects, we need to filter out anything that's not

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import * as cborg from 'cborg'
 import CID from 'multiformats/cid'
-import { codec } from 'multiformats/codecs/codec'
+import { Decoder, Encoder } from 'multiformats/codecs/codec'
 
 // https://github.com/ipfs/go-ipfs/issues/3570#issuecomment-273931692
 const CID_CBOR_TAG = 42
@@ -104,4 +104,7 @@ function decode (data) {
   return cborg.decode(data, decodeOptions)
 }
 
-export default codec({ name, code, encode, decode })
+const decoder = new Decoder(name, code, decode)
+const encoder = new Encoder(name, code, encode)
+
+export { name, code, decode, encode, decoder, encoder }

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -2,7 +2,7 @@
 'use strict'
 import garbage from 'ipld-garbage'
 import chai from 'chai'
-import dagcbor from '../index.js'
+import * as dagcbor from '../index.js'
 import { bytes, CID } from 'multiformats'
 
 const { encode, decode } = dagcbor


### PR DESCRIPTION
Default exports don't work well with CommonJS and TypeScript. Hence replace
the default export with an object export.

BREAKING CHANGE: import of dag-cbor changed

Prior to this change this module was imported as

```js
import dagcbor from '@ipld/dag-cbor'
```

Now it is imported as

```js
import * as dagcbor from `@ipld/dag-cbor'
```