### PR TITLE
fix: type annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,23 +98,19 @@ const decodeOptions = {
 }
 decodeOptions.tags[CID_CBOR_TAG] = cidDecoder
 
+export const name = 'dag-cbor'
+export const code = 0x71
+
 /**
  * @template T
- * @type {BlockCodec<0x71, T>}
+ * @param {T} node
+ * @returns {Uint8Array}
  */
-export const { name, code, decode, encode } = {
-  name: 'dag-cbor',
-  code: 0x71,
-  /**
-   * @template T
-   * @param {T} node
-   * @returns {Uint8Array}
-   */
-  encode: (node) => cborg.encode(node, encodeOptions),
-  /**
-   * @template T
-   * @param {Uint8Array} data
-   * @returns {T}
-   */
-  decode: (data) => cborg.decode(data, decodeOptions)
-}
+export const encode = (node) => cborg.encode(node, encodeOptions)
+
+/**
+ * @template T
+ * @param {Uint8Array} data
+ * @returns {T}
+ */
+export const decode = (data) => cborg.decode(data, decodeOptions)

--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 import * as cborg from 'cborg'
 import { CID } from 'multiformats/cid'
 
-/**
- * @template {number} Code
- * @template T
- * @typedef {import('multiformats/codecs/interface').BlockCodec<Code, T>} BlockCodec
- */
-
 // https://github.com/ipfs/go-ipfs/issues/3570#issuecomment-273931692
 const CID_CBOR_TAG = 42
 

--- a/test/ts-use/tsconfig.json
+++ b/test/ts-use/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "incremental": true
   }
 }


### PR DESCRIPTION
Fixes #24 

As per #24 issue generic declared on value caused invalid types to be generate 

https://github.com/ipld/js-dag-cbor/blob/a49da7e8d4008c995c829c6cf04f2746ee39774b/index.js#L101-L116

Which looked like this:

```js
export const encode: (data: T) => import("multiformats/codecs/interface").ByteView<T>;
```

TS does non really has equivalent of generic value in TS syntax and my guess is it just gets tripped over the by the thing in JSDoc.


I should also note that `const { code, name ... } = ...` also is not going to work, because of how TS infers types, if you create `const { code: 2 }` it is inferred as `{ code: number }` but if you do `const code = 2` code will be inferred as `2` as TS knows it can never change (unlike object). More details here https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#reverting-template-literal-inference

For those reason this change just dose `export const` to allow TS infer all as needed & I've verified that it addresses the problem.