### PR TITLE
feat!: coerce undefined to null on decode

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function cidDecoder (bytes) {
 
 const decodeOptions = {
   allowIndefinite: false,
-  allowUndefined: false,
+  coerceUndefinedToNull: true,
   allowNaN: false,
   allowInfinity: false,
   allowBigInt: true, // this will lead to BigInt for ints outside of

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "import": "./index.js"
   },
   "dependencies": {
-    "cborg": "^1.5.4",
+    "cborg": "^1.6.0",
     "multiformats": "^9.5.4"
   },
   "devDependencies": {

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -80,12 +80,6 @@ describe('dag-cbor', () => {
     assert.throws(() => encode(objWithUndefined), /\Wundefined\W.*not supported/)
   })
 
-  test('error on decoding undefined', () => {
-    // encoded forms from the encode() test above
-    assert.throws(() => decode(bytes.fromHex('f7')), /\Wundefined\W.*not supported/)
-    assert.throws(() => decode(bytes.fromHex('a2616161616162f7')), /\Wundefined\W.*not supported/)
-  })
-
   test('error on encoding IEEE 754 specials', () => {
     for (const special of [NaN, Infinity, -Infinity]) {
       assert.throws(() => encode(special), new RegExp(`\\W${String(special)}\\W.*not supported`))
@@ -171,5 +165,16 @@ describe('dag-cbor', () => {
     // CID replaced with 0x01 .......................  ↓↓ here
     const encoded = bytes.fromHex('a1646c696e6bd82a582501017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5')
     assert.throws(() => decode(encoded), /Invalid CID for CBOR tag 42; expected leading 0x00/)
+  })
+
+  test('sloppy decode: coerce undefined', () => {
+    // See https://github.com/ipld/js-dag-cbor/issues/44 for context on this
+    let encoded = bytes.fromHex('f7')
+    let decoded = decode(encoded)
+    same(null, decoded)
+
+    encoded = bytes.fromHex('a26362617af763666f6f63626172')
+    decoded = decode(encoded)
+    same({ foo: 'bar', baz: null }, decoded)
   })
 })


### PR DESCRIPTION
Ref: https://github.com/ipld/js-dag-cbor/issues/44 (read this if you want the background)
Ref: https://github.com/ipld/go-ipld-prime/pull/308

~~This is a WIP because I don't have the tools to easily perform a coercion yet; I need to do something in cborg so I don't have to get dirty with the token stream, which is currently the only way to do this here. It may be as simple as a `coerceUndefinedToNull` option or something like that, or there may be a straightforward way to have a type translation option like I have for the encoder side, which is quite a nice feature.~~

~~Currently tests are failing because it doesn't coerce, but lets the `undefined` through, but the tests are in place and they'll pass as soon as the rest is done.~~

Using the new `coerceUndefinedToNull` option in cborg to do the dirty work. See #44 for more info.