### PR TITLE
use `esbuild` to create a `cjs` bundle

### DIFF
--- a/build-cjs.js
+++ b/build-cjs.js
@@ -1,0 +1,12 @@
+import esbuild from 'esbuild'
+
+esbuild.build({
+  entryPoints: ['./src/index.js'],
+  bundle: true,
+  packages: 'external',
+  format: 'cjs',
+  sourcemap: true,
+  platform: 'node',
+  outfile: 'dist/cjs/index.js',
+  allowOverwrite: true
+})

--- a/package.json
+++ b/package.json
@@ -149,8 +149,8 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
-    "build:cjs": "node ./build-cjs.js && echo {\"type\": \"commonjs\"} > ./dist/cjs/package.json",
-    "build": "aegir build",
+    "build:cjs": "node ./build-cjs.cjs && echo {\"type\": \"commonjs\"} > ./dist/cjs/package.json",
+    "build": "aegir build && npm run build:cjs",
     "release": "aegir release",
     "test": "npm run lint && aegir test",
     "test:ts": "npm run test --prefix test/ts-use",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "eslintConfig": {
@@ -148,6 +149,7 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
+    "build:cjs": "node ./build-cjs.js && echo {\"type\": \"commonjs\"} > ./dist/cjs/package.json",
     "build": "aegir build",
     "release": "aegir release",
     "test": "npm run lint && aegir test",
@@ -166,6 +168,7 @@
   },
   "devDependencies": {
     "@ipld/garbage": "^6.0.0",
+    "esbuild": "0.17.14",
     "aegir": "^37.5.6",
     "buffer": "^6.0.3"
   }


### PR DESCRIPTION
Unfortunately, electron only supports cjs which is where we're trying to use this library. 

This PR uses `esbuild` to create a `cjs` bundle. I noticed that y'all use `aegir` across many ipfs projects for bundling and testing. i suppose we could introduce an option there that builds `cjs` bundles when toggled on. That'll take some digging though

I've gone ahead and updated the `exports` object in `package.json` to include the `cjs` version of everything that's exported.