### PR TITLE
chore: cborg@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,11 +161,11 @@
     "dep-check": "aegir dep-check"
   },
   "dependencies": {
-    "cborg": "^2.0.1",
-    "multiformats": "^12.0.1"
+    "cborg": "^3.0.0-alpha.1",
+    "multiformats": "^12.1.1"
   },
   "devDependencies": {
-    "@ipld/garbage": "^6.0.0",
-    "aegir": "^40.0.8"
+    "@ipld/garbage": "^6.0.3",
+    "aegir": "^40.0.13"
   }
 }


### PR DESCRIPTION
updates to ESM-only cborg

---

currently draft cause 3.0.0 isn't released yet, https://github.com/rvagg/cborg/pull/91, just testing