### PR TITLE
feat: export encode/decode -Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ import { decodeFirst } from 'cborg'
 const byteLength = encodedLength(obj, encodeOptions)
 byteLength // 104
 
-
 // concatenate two dag-cbor encoded obj
 const concatenatedData = new Uint8Array(data.length * 2)
 concatenatedData.set(data)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ let data = encode(obj)
 let decoded = decode(data)
 decoded.y[0] // 2
 CID.asCID(decoded.z.a) // cid instance
+
+// encode/decode options are exported for use with cborg's encodedLength and decodeFirst
+import { encodeOptions, decodeOptions } from '@ipld/dag-cbor'
+import { encodedLength } from 'cborg/length'
+import { decodeFirst } from 'cborg'
+
+// dag-cbor encoded length of obj in bytes
+const byteLength = encodedLength(obj, encodeOptions)
+byteLength // 104
+
+
+// concatenate two dag-cbor encoded obj
+const concatenatedData = new Uint8Array(data.length * 2)
+concatenatedData.set(data)
+concatenatedData.set(data, data.length)
+
+// returns dag-cbor decoded obj at the beginning of the buffer as well as the remaining bytes
+const [first, remainder] = decodeFirst(concatenatedData, decodeOptions)
+assert.deepStrictEqual(first, obj)
+assert.deepStrictEqual(remainder, data)
 ```
 
 ## Spec

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ function numberEncoder (num) {
   return null
 }
 
-const encodeOptions = {
+export const encodeOptions = {
   float64: true,
   typeEncoders: {
     Object: cidEncoder,
@@ -84,7 +84,7 @@ function cidDecoder (bytes) {
   return CID.decode(bytes.subarray(1)) // ignore leading 0x00
 }
 
-const decodeOptions = {
+export const decodeOptions = {
   allowIndefinite: false,
   coerceUndefinedToNull: true,
   allowNaN: false,

--- a/src/index.js
+++ b/src/index.js
@@ -64,12 +64,19 @@ function numberEncoder (num) {
   return null
 }
 
-export const encodeOptions = {
+const _encodeOptions = {
   float64: true,
   typeEncoders: {
     Object: cidEncoder,
     undefined: undefinedEncoder,
     number: numberEncoder
+  }
+}
+
+export const encodeOptions = {
+  ..._encodeOptions,
+  typeEncoders: {
+    ..._encodeOptions.typeEncoders
   }
 }
 
@@ -84,7 +91,7 @@ function cidDecoder (bytes) {
   return CID.decode(bytes.subarray(1)) // ignore leading 0x00
 }
 
-export const decodeOptions = {
+const _decodeOptions = {
   allowIndefinite: false,
   coerceUndefinedToNull: true,
   allowNaN: false,
@@ -97,7 +104,12 @@ export const decodeOptions = {
   /** @type {import('cborg').TagDecoder[]} */
   tags: []
 }
-decodeOptions.tags[CID_CBOR_TAG] = cidDecoder
+_decodeOptions.tags[CID_CBOR_TAG] = cidDecoder
+
+export const decodeOptions = {
+  ..._decodeOptions,
+  tags: _decodeOptions.tags.slice()
+}
 
 export const name = 'dag-cbor'
 export const code = 0x71
@@ -107,11 +119,11 @@ export const code = 0x71
  * @param {T} node
  * @returns {ByteView<T>}
  */
-export const encode = (node) => cborg.encode(node, encodeOptions)
+export const encode = (node) => cborg.encode(node, _encodeOptions)
 
 /**
  * @template T
  * @param {ByteView<T>} data
  * @returns {T}
  */
-export const decode = (data) => cborg.decode(data, decodeOptions)
+export const decode = (data) => cborg.decode(data, _decodeOptions)

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -181,4 +181,11 @@ describe('dag-cbor', () => {
     const encoded = bytes.fromHex('a3636261720363666f6f0163666f6f02')
     assert.throws(() => decode(encoded), /CBOR decode error: found repeat map key "foo"/)
   })
+
+  test('exports encode and decode options', () => {
+    const { encodeOptions, decodeOptions } = dagcbor
+
+    assert.isDefined(encodeOptions)
+    assert.isDefined(decodeOptions)
+  })
 })


### PR DESCRIPTION
These options are being exported so they can be used with
cborg's API, specifically the `decodeFirst` and `encodedLength` functions.

Closes https://github.com/ipld/js-dag-cbor/issues/112
