### PR TITLE
feat: support decoding ArrayBuffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "cborg": "^4.0.0",
-    "multiformats": "^13.0.0"
+    "multiformats": "^13.1.0"
   },
   "devDependencies": {
     "@ipld/garbage": "^6.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,24 @@ const CID_CBOR_TAG = 42
  */
 
 /**
+ * @template T
+ * @typedef {import('multiformats/codecs/interface').ArrayBufferView<T>} ArrayBufferView
+ */
+
+/**
+ * @template T
+ * @param {ByteView<T> | ArrayBufferView<T>} buf
+ * @returns {ByteView<T>}
+ */
+export function toByteView (buf) {
+  if (buf instanceof ArrayBuffer) {
+    return new Uint8Array(buf, 0, buf.byteLength)
+  }
+
+  return buf
+}
+
+/**
  * cidEncoder will receive all Objects during encode, it needs to filter out
  * anything that's not a CID and return `null` for that so it's encoded as
  * normal.
@@ -123,7 +141,7 @@ export const encode = (node) => cborg.encode(node, _encodeOptions)
 
 /**
  * @template T
- * @param {ByteView<T>} data
+ * @param {ByteView<T> | ArrayBufferView<T>} data
  * @returns {T}
  */
-export const decode = (data) => cborg.decode(data, _decodeOptions)
+export const decode = (data) => cborg.decode(toByteView(data), _decodeOptions)

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -39,6 +39,20 @@ describe('dag-cbor', () => {
     same(deserializedObj, obj)
   })
 
+  test('.serialize and .deserialize with ArrayBuffer', () => {
+    same(bytes.isBinary(serializedObj), true)
+
+    // Check for the tag 42
+    // d8 = tag, 2a = 42
+    same(bytes.toHex(serializedObj).match(/d82a/g)?.length, 4)
+
+    const deserializedObj = decode(serializedObj.buffer.slice(
+        serializedObj.byteOffset,
+        serializedObj.byteOffset + serializedObj.byteLength)
+    )
+    same(deserializedObj, obj)
+  })
+
   test('.serialize and .deserialize large objects', () => {
     // larger than the default borc heap size, should auto-grow the heap
     const dataSize = 128 * 1024

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -47,8 +47,8 @@ describe('dag-cbor', () => {
     same(bytes.toHex(serializedObj).match(/d82a/g)?.length, 4)
 
     const deserializedObj = decode(serializedObj.buffer.slice(
-        serializedObj.byteOffset,
-        serializedObj.byteOffset + serializedObj.byteLength)
+      serializedObj.byteOffset,
+      serializedObj.byteOffset + serializedObj.byteLength)
     )
     same(deserializedObj, obj)
   })

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -37,7 +37,7 @@ function useDecoder<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Arr
 
 function useDecoderWithArrayBuffer<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
   deepStrictEqual(decoder.code, 0x70)
-  deepStrictEqual(decoder.decode(Uint8Array.from([100, 98, 108, 105, 112]).slice.buffer), 'blip')
+  deepStrictEqual(decoder.decode(Uint8Array.from([100, 98, 108, 105, 112]).buffer), 'blip')
   console.log('[TS] ✓ { decoder: BlockDecoder }')
 }
 

--- a/test/ts-use/src/main.ts
+++ b/test/ts-use/src/main.ts
@@ -15,6 +15,9 @@ function useCodecFeature (codec: BlockCodec<0x71, any>) {
   // use only as a BlockDecoder
   useDecoder(codec)
 
+  // use with ArrayBuffer input type
+  useDecoderWithArrayBuffer(codec)
+
   // use as a full BlockCodec which does both BlockEncoder & BlockDecoder
   useBlockCodec(codec)
 }
@@ -29,6 +32,12 @@ function useEncoder<Codec extends number> (encoder: BlockEncoder<Codec, string>)
 function useDecoder<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
   deepStrictEqual(decoder.code, 0x71)
   deepStrictEqual(decoder.decode(Uint8Array.from([100, 98, 108, 105, 112])), 'blip')
+  console.log('[TS] ✓ { decoder: BlockDecoder }')
+}
+
+function useDecoderWithArrayBuffer<Codec extends number> (decoder: BlockDecoder<Codec, Uint8Array>) {
+  deepStrictEqual(decoder.code, 0x70)
+  deepStrictEqual(decoder.decode(Uint8Array.from([100, 98, 108, 105, 112]).slice.buffer), 'blip')
   console.log('[TS] ✓ { decoder: BlockDecoder }')
 }
 


### PR DESCRIPTION
Expands supported input types to include `ArrayBuffer`s to make it easiser for users to use modules like `fetch` that don't return `Uint8Array`s.