### PR TITLE
chore: omit lockfile from release commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,9 @@
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/github",
-      "@semantic-release/git"
+      ["@semantic-release/git", {
+        "assets": ["CHANGELOG.md", "package.json"]
+      }]
     ]
   },
   "scripts": {


### PR DESCRIPTION
Turns out ignoring `.gitignore` while adding files to the release commit is a feature not a bug so specify the list of files to add.

We didn't trigger it in the past because we didn't add the lockfile to the build cache so it wasn't copied into the container for the release build step.  Now we do in order to support projects (like apps) that want a lockfile so we need to specify the asset files in the config.

Refs: https://github.com/semantic-release/git/pull/56

We can probably revert/update if https://github.com/semantic-release/git/pull/527 ever gets merged.